### PR TITLE
How to become a committer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,67 +25,75 @@ KServe working group.
 
 ## Code of conduct
 
-All members of the KServe community must abide by the [Code of Conduct](https://github.com/lfai/foundation/blob/main/codeofconduct.md).
+All members of the KServe community must abide by the
+[Code of Conduct](https://github.com/lfai/foundation/blob/main/codeofconduct.md).
 
 ## Design documents
 
-Any substantial design deserves a design document. Design documents are written with Google Docs and
-should be shared with the community by adding the doc to our shared Drive
-and sending a note to the working group to let people know the doc is there.
+Any substantial design deserves a design document. Design documents are written
+with Google Docs and should be shared with the community by adding the doc to
+our shared Drive and sending a note to the working group to let people know the
+doc is there.
 
 When documenting a new design, we recommend a 2-step approach:
 
-1. Use the short-form
-[RFC template](https://docs.google.com/document/d/1UcBeLfZ_JMGpVrPJmYtEIVH_9Y4U3AEKQdq_IKuOMrU)
-to outline your ideas and get early feedback.
-1. Once you have received sufficient feedback and consensus, you may use the longer-form
-[design doc template](https://docs.google.com/document/d/1Mtoui_PP2a9N59NjYHnsvrdJ8t2iKFwIJAx1zRO_I1c)
-to specify and discuss your design in more details.
+1. Use the short-form [RFC template](https://docs.google.com/document/d/1UcBeLfZ_JMGpVrPJmYtEIVH_9Y4U3AEKQdq_IKuOMrU) to outline your ideas and get early feedback.
 
-To use either template, open the template and select "Use Template" in order to bootstrap your document.
+2. Once you have received sufficient feedback and consensus, you may use the longer-form [design doc template](https://docs.google.com/document/d/1Mtoui_PP2a9N59NjYHnsvrdJ8t2iKFwIJAx1zRO_I1c) to specify and discuss your design in more details.
+
+To use either template, open the template and select "Use Template" in order to
+bootstrap your document.
 
 ## Contributing a feature
 
-In order to contribute a feature to KServe you'll need to go through the following steps:
+In order to contribute a feature to KServe you'll need to go through the
+following steps:
 
-- Discuss your idea with the working group on slack or discussion thread.
+- Discuss your idea with the working group on Slack or discussion thread.
 
-- Once there is general agreement that the feature is useful, create a GitHub issue to track the discussion. The issue should include information
-about the requirements and use cases that it is trying to address. Include a discussion of the proposed design and technical details of the
-implementation in the issue.
+- Once there is general agreement that the feature is useful, create a GitHub
+  issue to track the discussion. The issue should include information about the
+  requirements and use cases that it is trying to address. Include a discussion
+  of the proposed design and technical details of the implementation in the issue.
 
 - If the feature is substantial enough:
 
-  - Working group leads will ask for a design document as outlined in the previous section.
-  Create the design document and add a link to it in the GitHub issue. Don't forget to send a note to the
-  working group to let everyone know your document is ready for review.
+  - Working group leads will ask for a design document as outlined in the
+    previous section. Create the design document and add a link to it in the
+    GitHub issue. Don't forget to send a note to the working group to let
+    everyone know your document is ready for review.
 
-  - Depending of the breath of the design and how contentious it is, the working group leads may decide
-  the feature needs to be discussed in one or more working group meetings before being approved.
+  - Depending on the breadth of the design and how contentious it is, the
+    working group leads may decide the feature needs to be discussed in one
+    or more working group meetings before being approved.
 
-  - Once the major technical issues are resolved and agreed upon, post a note to the working group's mailing
-  list with the design decision and the general execution plan.
+  - Once the major technical issues are resolved and agreed upon, post a
+    note to the working group's mailing list with the design decision and
+    the general execution plan.
 
-- Submit PRs to [kserve/kserve](https://github.com/kserve/kserve) with your code changes.
+- Submit PRs to [kserve/kserve](https://github.com/kserve/kserve) with your
+  code changes.
 
 - Submit PRs to [kserve/website](https://github.com/kserve/website) with
-documentation for your feature, including usage examples when possible. See [here](https://github.com/kserve/website/blob/main/docs/help/contributor/mkdocs-contributor-guide.md)
-to learn how to write docs for kserve.io.
+  documentation for your feature, including usage examples when possible.
+  See [here](https://github.com/kserve/website/blob/main/docs/help/contributor/mkdocs-contributor-guide.md) to learn how to write docs for kserve.io.
 
-> Note that we prefer bite-sized PRs instead of giant monster PRs. It's therefore preferable if you
-can introduce large features in smaller reviewable changes that build on top of one another.
+Note, that we prefer "bite-sized" PRs instead of "giant monster" PRs. It is
+preferable if you can introduce large features in smaller reviewable changes
+that build on top of one another.
 
-If you would like to skip the process of submitting an issue and
-instead would prefer to just submit a pull request with your desired
-code changes then that's fine. But keep in mind that there is no guarantee
-of it being accepted and so it is usually best to get agreement on the
-idea/design before time is spent coding it. However, sometimes seeing the
-exact code change can help focus discussions, so the choice is up to you.
+If you would like to skip the process of submitting an issue and instead would
+prefer to just submit a pull request with your desired code changes then that's
+fine. But keep in mind that there is no guarantee of it being accepted and so
+it is usually best to get agreement on the idea/design before time is spent
+coding it. However, sometimes seeing the exact code change can help focus
+discussions, so the choice is up to you.
+
 
 ## Setting up to contribute to KServe
 
-Check out this [README](https://github.com/kserve/kserve/blob/master/README.md) to learn about
-the KServe source base and setting up your [development environment](https://kserve.github.io/website/master/developer/developer/).
+Check out this [README](https://github.com/kserve/kserve/blob/master/README.md)
+to learn about the KServe source base and setting up your [development environment](https://kserve.github.io/website/master/developer/developer/).
 
 ## Pull requests
 
@@ -115,16 +123,17 @@ While there may be exceptions, the general rule is that all PRs should
 be 100% complete - meaning they should include all test cases and documentation
 changes related to the change.
 
-When ready, if you have not already done so, [sign off the commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) and submit
-the PR.
+Make sure to [sign off your commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+before you submit your PR.
 
-See [Writing Good Pull Requests](https://github.com/istio/istio/wiki/Writing-Good-Pull-Requests) for guidance on creating
-pull requests, and [Reviewing Pull Requests](https://github.com/istio/istio/wiki/Reviewing-Pull-Requests) for the PR review
-we use.
+Take a look at the article on [Writing Good Pull Requests](https://github.com/istio/istio/wiki/Writing-Good-Pull-Requests) for additional guidance.
+And check out the article on [Reviewing Pull Requests](https://github.com/istio/istio/wiki/Reviewing-Pull-Requests) to learn more about our PR
+review process.
 
 ## Issues
 
-[GitHub issues](https://github.com/kserve/kserve/issues/new/choose) can be used to report bugs or submit feature requests.
+[GitHub issues](https://github.com/kserve/kserve/issues/new/choose) can be used
+to report bugs or submit feature requests.
 
 When reporting a bug please include the following key pieces of information:
 
@@ -139,17 +148,19 @@ When reporting a bug please include the following key pieces of information:
 
 ## Promote your company on kserve.io
 
-If your company supports KServe or uses in on production, you can list it on our [adopters page](https://kserve.github.io/website/master/community/adopters).
+If your company supports KServe or uses in on production, you can list it on our
+[adopters page](https://kserve.github.io/website/master/community/adopters).
 We have categories for *providers* (who offer hosted or managed KServe services
-to their customers), *end user* (who use and consume KServe) and *integrations* (commercial or open source products
-that work with KServe).
+to their customers), *end user* (who use and consume KServe) and *integrations*
+(commercial or open source products that work with KServe).
 
 Please add your company logo, preferably in SVG format, to [here](https://github.com/kserve/website/tree/main/docs/images).
 
 ## Becoming a committer
 
-A committer is a contributor who has gained the privilege to commit code to the project. 
-But being a committer also means being committed to the project and the community as a whole.
+A committer is a contributor who has gained the privilege to commit code to the
+project. But being a committer also means being committed to the project and the
+community as a whole.
 
 **Responsibilities of a committer:**
 
@@ -159,17 +170,24 @@ But being a committer also means being committed to the project and the communit
 - Answer questions on Slack
 - Mentor new project contributors
 
-Contributors who have demonstrated their proficiency to make substantial code contributions and shown their commitment to the projects success over a prolonged period of time are candidates to become committers.
+Contributors who have demonstrated their proficiency to make substantial code
+contributions and shown their commitment to the projects success over a
+prolonged period of time are candidates to become committers.
 
-### How new committers are chosen
+**How new committers are chosen:**
 
-The [KServe Technical Charter](./KSERVE-TECHICAL-CHARTER.md#2-technical-steering-committee) outlines the process to become a KServe committer:
+The [KServe Technical Charter](./KSERVE-TECHICAL-CHARTER.md#2-technical-steering-committee)
+outlines the process to become a KServe committer:
 
 > - **iii**. A _Contributor_ may become a _Committer_ by a majority approval of the existing Committers. A Committer may be removed by a majority approval of the other existing Committers. 
 
-For this purpose, the technical steering committee (TSC) shall periodically review the activity of project contributors and propose qualifying contributors to be promoted to become committers.
+For this purpose, the technical steering committee (TSC) shall periodically
+review the activity of project contributors and propose qualifying contributors
+to be promoted to become committers.
 
-To help find candidates for promotion, existing committers can use the [`list-contributors.py`](scripts/python/list-contributors.py) script to review recent contributor activity:
+To help find candidates for promotion, existing committers can use the
+[`list-contributors.py`](scripts/python/list-contributors.py) script to review
+recent contributor activity:
 
 ```shell
 $ make list-pr-authors
@@ -190,4 +208,29 @@ Contributors to 'kserve/kserve' (PR commenters, reviewers) by number of PRs (>3)
   4  casualcodr      [5062, 5039, 5025, 4867]
 ```
 
-This script should only be used to identify suitable candidates. The actual candidate selection should take more factors into consideration than number of commits or PRs reviewed.
+This script should only be used to identify suitable candidates. The actual
+candidate selection should take more factors into consideration than number of
+commits or PRs reviewed.
+
+**Areas of expertise:**
+
+Another criteria in selecting new committers is the project area that requires
+help with reviewing PRs and mentoring new contributors. Contributors that have
+a lot of expertise in a particular area who have helped review PRs in their area
+of expertise make good candidates to be promoted as committers. The various
+projects under the KServe umbrella may have a different set of committers and
+focus areas.
+
+Some of those areas of expertise include:
+
+- **KServe**:
+  - Python SDK
+  - Open inference protocol, data plane
+  - Release & testing infra
+  - Webapp
+  - Website
+- **ModelMesh**:
+  - Controller
+  - Runtime adapter
+  - Storage adapter
+  - Rest proxy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,3 +145,49 @@ to their customers), *end user* (who use and consume KServe) and *integrations* 
 that work with KServe).
 
 Please add your company logo, preferably in SVG format, to [here](https://github.com/kserve/website/tree/main/docs/images).
+
+## Becoming a committer
+
+A committer is a contributor who has gained the privilege to commit code to the project. 
+But being a committer also means being committed to the project and the community as a whole.
+
+**Responsibilities of a committer:**
+
+- Triage and respond to issues
+- Be an expert in certain areas, but familiar with the majority of the code base
+- Review pull requests
+- Answer questions on Slack
+- Mentor new project contributors
+
+Contributors who have demonstrated their proficiency to make substantial code contributions and shown their commitment to the projects success over a prolonged period of time are candidates to become committers.
+
+### How new committers are chosen
+
+The [KServe Technical Charter](./KSERVE-TECHICAL-CHARTER.md#2-technical-steering-committee) outlines the process to become a KServe committer:
+
+> - **iii**. A _Contributor_ may become a _Committer_ by a majority approval of the existing Committers. A Committer may be removed by a majority approval of the other existing Committers. 
+
+For this purpose, the technical steering committee (TSC) shall periodically review the activity of project contributors and propose qualifying contributors to be promoted to become committers.
+
+To help find candidates for promotion, existing committers can use the [`list-contributors.py`](scripts/python/list-contributors.py) script to review recent contributor activity:
+
+```shell
+$ make list-pr-authors
+
+Contributors to 'kserve/kserve' (PR authors) by number of PRs (>3) since 2023-03-02:
+
+ 39  supercoder      [5083, 5077, 5040, 5038, 5035, 5031, 5024, 5016, 5006, 5004, ... ]
+ 20  kservehacker    [5089, 5061, 5054, 5029, 5020, 5002, 5001, 4998, 4956, 4952, ... ]
+  6  code4fun        [5069, 5048, 5027, 5026, 5008, 4867]
+
+
+$ make list-pr-reviewers
+
+Contributors to 'kserve/kserve' (PR commenters, reviewers) by number of PRs (>3) since 2023-03-02:
+
+ 13  reviewchamp     [5089, 5075, 5072, 5047, 5042, 5040, 5038, 5031, 4993, 4969, ... ]
+  9  nitpickr        [5079, 5054, 5049, 5040, 4954, 4877, 4782, 4762, 4739]
+  4  casualcodr      [5062, 5039, 5025, 4867]
+```
+
+This script should only be used to identify suitable candidates. The actual candidate selection should take more factors into consideration than number of commits or PRs reviewed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,8 +159,9 @@ Please add your company logo, preferably in SVG format, to [here](https://github
 ## Becoming a committer
 
 A committer is a contributor who has gained the privilege to commit code to the
-project. It also means being committed to the project and the
-community as a whole.
+project. It also means being committed to the project and the community as a whole.
+Contributors who aspire to become committers should already be doing most of the
+activities that are expected to be done by the project's committers.
 
 **Responsibilities of a committer:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ When ready, if you have not already done so, [sign off the commits](https://docs
 the PR.
 
 See [Writing Good Pull Requests](https://github.com/istio/istio/wiki/Writing-Good-Pull-Requests) for guidance on creating
-pull requests, and [Reviewing Pull Requests]() for the PR review
+pull requests, and [Reviewing Pull Requests](https://github.com/istio/istio/wiki/Reviewing-Pull-Requests) for the PR review
 we use.
 
 ## Issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ When documenting a new design, we recommend a 2-step approach:
 
 1. Use the short-form [RFC template](https://docs.google.com/document/d/1UcBeLfZ_JMGpVrPJmYtEIVH_9Y4U3AEKQdq_IKuOMrU) to outline your ideas and get early feedback.
 
-2. Once you have received sufficient feedback and consensus, you may use the longer-form [design doc template](https://docs.google.com/document/d/1Mtoui_PP2a9N59NjYHnsvrdJ8t2iKFwIJAx1zRO_I1c) to specify and discuss your design in more details.
+2. Once you have received sufficient feedback and consensus, you may use the longer-form [design doc template](https://docs.google.com/document/d/1Mtoui_PP2a9N59NjYHnsvrdJ8t2iKFwIJAx1zRO_I1c) to specify and discuss your design in more detail.
 
 To use either template, open the template and select "Use Template" in order to
 bootstrap your document.
@@ -49,7 +49,7 @@ bootstrap your document.
 In order to contribute a feature to KServe you'll need to go through the
 following steps:
 
-- Discuss your idea with the working group on Slack or discussion thread.
+- Discuss your idea with the working group on Slack in a discussion thread.
 
 - Once there is general agreement that the feature is useful, create a GitHub
   issue to track the discussion. The issue should include information about the
@@ -148,10 +148,10 @@ When reporting a bug please include the following key pieces of information:
 
 ## Promote your company on kserve.io
 
-If your company supports KServe or uses in on production, you can list it on our
+If your company supports KServe or uses it in production, you can list it on our
 [adopters page](https://kserve.github.io/website/master/community/adopters).
 We have categories for *providers* (who offer hosted or managed KServe services
-to their customers), *end user* (who use and consume KServe) and *integrations*
+to their customers), *end users* (who use and consume KServe) and *integrations*
 (commercial or open source products that work with KServe).
 
 Please add your company logo, preferably in SVG format, to [here](https://github.com/kserve/website/tree/main/docs/images).
@@ -159,13 +159,13 @@ Please add your company logo, preferably in SVG format, to [here](https://github
 ## Becoming a committer
 
 A committer is a contributor who has gained the privilege to commit code to the
-project. But being a committer also means being committed to the project and the
+project. It also means being committed to the project and the
 community as a whole.
 
 **Responsibilities of a committer:**
 
 - Triage and respond to issues
-- Be an expert in certain areas, but familiar with the majority of the code base
+- Possess expertise in certain areas and familiarity with the majority of the code base
 - Review pull requests
 - Answer questions on Slack
 - Mentor new project contributors
@@ -214,10 +214,10 @@ commits or PRs reviewed.
 
 **Areas of expertise:**
 
-Another criteria in selecting new committers is the project area that requires
+Another criterion to use when selecting new committers is the project area that requires
 help with reviewing PRs and mentoring new contributors. Contributors that have
-a lot of expertise in a particular area who have helped review PRs in their area
-of expertise make good candidates to be promoted as committers. The various
+a lot of expertise in a particular area who have helped review PRs in that area
+make good candidates to be promoted as committers. The various
 projects under the KServe umbrella may have a different set of committers and
 focus areas.
 

--- a/KSERVE-TECHICAL-CHARTER.md
+++ b/KSERVE-TECHICAL-CHARTER.md
@@ -16,10 +16,11 @@ a. The Technical Steering Committee (the “TSC”) will be responsible for all 
 
 b. The TSC voting members are initially the Project’s Committers. At the inception of the project, the Committers of the Project will be set forth within the “CONTRIBUTING” file within the Project’s code repository. The TSC may choose an alternative approach for determining the voting members of the TSC, and any such alternative approach will be documented in the CONTRIBUTING file. Any meetings of the Technical Steering Committee are intended to be open to the public, and can be conducted electronically, via teleconference, or in person. 
 
-c. TSC projects generally will involve Contributors and Committers. The TSC may adopt or modify roles so long as the roles are documented in the CONTRIBUTING file. Unless otherwise documented: 
-       i. Contributors include anyone in the technical community that contributes code, documentation, or other technical artifacts to the Project; 
-      ii. Committers are Contributors who have earned the ability to modify (“commit”) source code, documentation or other technical artifacts in a project’s repository; and
-      iii. A Contributor may become a Committer by a majority approval of the existing Committers. A Committer may be removed by a majority approval of the other existing Committers. 
+c. TSC projects generally will involve Contributors and Committers. The TSC may adopt or modify roles so long as the roles are documented in the CONTRIBUTING file. Unless otherwise documented:
+
+  i. _Contributors_ include anyone in the technical community that contributes code, documentation, or other technical artifacts to the Project; 
+  ii. _Committers_ are Contributors who have earned the ability to modify (“commit”) source code, documentation or other technical artifacts in a project’s repository; and
+  iii. A Contributor may **become a Committer** by a majority approval of the existing Committers. A Committer may be removed by a majority approval of the other existing Committers. 
 
 d. Participation in the Project through becoming a Contributor and Committer is open to anyone so long as they abide by the terms of this Charter. 
 

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,19 @@ check-doc-links:
 	@python3 scripts/python/verify-doc-links.py && echo "$@: OK"
 
 .PHONY: list-contributors
-## Verify URL links in Markdown files
+## List top contributors
 list-contributors:
 	@python3 scripts/python/list-contributors.py
 
+.PHONY: list-pr-reviewers
+## List top PR reviewers
+list-pr-reviewers:
+	@python3 scripts/python/list-contributors.py -r reviewer commenter
+
+.PHONY: list-pr-authors
+## List top PR authors
+list-pr-authors:
+	@python3 scripts/python/list-contributors.py -r author
 
 .DEFAULT_GOAL := help
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ list-contributors:
 .PHONY: list-pr-reviewers
 ## List top PR reviewers
 list-pr-reviewers:
-	@python3 scripts/python/list-contributors.py -r reviewer commenter
+	@python3 scripts/python/list-contributors.py -r reviewer commenter -n 3
 
 .PHONY: list-pr-authors
 ## List top PR authors
 list-pr-authors:
-	@python3 scripts/python/list-contributors.py -r author
+	@python3 scripts/python/list-contributors.py -r author -n 3
 
 .DEFAULT_GOAL := help
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+
+.PHONY: check-doc-links
+## Verify URL links in Markdown files
+check-doc-links:
+	@python3 scripts/python/verify-doc-links.py && echo "$@: OK"
+
+.PHONY: list-contributors
+## Verify URL links in Markdown files
+list-contributors:
+	@python3 scripts/python/list-contributors.py
+
+
+.DEFAULT_GOAL := help
+.PHONY: help
+## Print Makefile documentation
+help:
+	@perl -0 -nle 'printf("\033[36m  %-20s\033[0m %s\n", "$$2", "$$1") while m/^##\s*([^\r\n]+)\n^([\w.-]+):[^=]/gm' $(MAKEFILE_LIST) | sort

--- a/scripts/python/list-contributors.py
+++ b/scripts/python/list-contributors.py
@@ -44,6 +44,7 @@ args.add_argument('-r',
                   default=[r.value for r in Role],
                   help="type of PR participation")
 args.add_argument('-n',
+                  metavar='THRESHOLD',
                   dest='min_num_prs', type=int,
                   default=5,
                   help="minimum number of PRs participated")
@@ -56,7 +57,11 @@ args.add_argument('-i',
                   dest='ignored_users', type=str, nargs='+',
                   default=[u for u in ignored_users],
                   help="users to be ignored")
-args.add_argument('-v',
+args.add_argument('--repo',
+                  dest='repo', type=str,
+                  default="kserve/kserve",
+                  help="GitHub repository")
+args.add_argument('-v', '--debug',
                   dest='debug', action="store_true",
                   help="debug")
 args.add_argument('-f',
@@ -72,9 +77,7 @@ min_prs_participated = opts.min_num_prs
 debug = opts.debug
 json_file = opts.json_file
 ignored_users = set(opts.ignored_users)
-
-# non-parameterized variables
-repo = "kserve/kserve"
+repo = opts.repo
 
 # the GitHub API requires an API token:
 # https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#authenticating-with-a-personal-access-token

--- a/scripts/python/list-contributors.py
+++ b/scripts/python/list-contributors.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 The KServe Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to find PR reviewers on the kserve/kserve repo
+
+import json
+from collections import defaultdict
+from datetime import date, timedelta
+from os import environ as env
+from urllib.request import Request, urlopen
+
+
+GITHUB_REPO = env.get("GITHUB_REPO", "kserve/kserve")
+GITHUB_API_TOKEN = env.get("GITHUB_API_TOKEN")
+
+repository = "kserve/kserve"
+bot = "kserve-oss-bot"
+dan = "yuzisun"
+six_months_ago = date.today() - timedelta(days=180)
+
+query_template = """
+{
+  query: search(
+    type: ISSUE
+    query: "repo:%s is:PR comments:>1 created:>%s"
+    first: %d
+    # after: "$cursor"
+    %s
+  )
+  {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on PullRequest {
+        author {
+          login
+        }
+        reviews(last: 10) {
+          nodes {
+            author {
+              login
+            }
+            state
+            createdAt
+          }
+        }
+        comments(last: 100) {
+          nodes {
+            author {
+              login
+            }
+            # bodyText
+          }
+        }
+        number
+        title
+        createdAt
+      }
+    }
+  }
+}
+"""
+
+
+def get_query_text(repository: str = repository,
+                   since_date: date = six_months_ago,
+                   num_results: int = 100,
+                   cursor: str = None) -> str:
+
+    query_txt = query_template % (
+        repository,
+        since_date.strftime('%Y-%m-%d'),
+        num_results,
+        f'after: "{cursor}"' if cursor else ""
+    )
+    return query_txt
+
+
+def force_ipv4():
+    # Monkey-patch socket.getaddrinfo to force IPv4 conections, since some older
+    # routers and some internet providers don't support IPv6, in which case Python
+    # will first try an IPv6 connection which will hang until timeout and only
+    # then attempt a successful IPv4 connection
+    import socket
+
+    # get a reference to the original getaddrinfo function
+    getaddrinfo_original = socket.getaddrinfo
+
+    # create a patched getaddrinfo function which uses the original function
+    # but filters out IPv6 (socket.AF_INET6) entries of host and port address infos
+    def getaddrinfo_patched(*args, **kwargs):
+        res = getaddrinfo_original(*args, **kwargs)
+        return [r for r in res if r[0] == socket.AF_INET]
+
+    # replace the original socket.getaddrinfo function with our patched version
+    socket.getaddrinfo = getaddrinfo_patched
+
+
+def run_query(query: str) -> str:
+    encoded_body = query.encode('utf8')
+    url = "https://api.github.com/graphql"
+    method = "POST"
+    headers = {
+        'Content-Type': 'application/json',
+        "Authorization": f"Bearer {GITHUB_API_TOKEN}"
+    }
+    timeout = 10
+    resp = None
+    resp_content = None
+
+    try:
+        req = Request(url, method=method, headers=headers, data=encoded_body)
+        resp = urlopen(req, timeout=timeout)
+        resp_content = resp.read().decode('utf8')
+    except Exception as e:
+        print(e)
+    finally:
+        if resp:
+            resp.close()
+
+    return resp_content
+
+
+def get_contributors() -> dict:
+    has_next_page = True
+    cursor = None
+    nodes = []
+    while has_next_page:
+        query_text = get_query_text(cursor=cursor)
+        query_json={'query': query_text}
+        query_json_str=json.dumps(query_json)
+        result_str = run_query(query_json_str)
+        result_json = json.loads(result_str)
+        page_info = result_json["data"]["query"]["pageInfo"]
+        has_next_page = page_info["hasNextPage"]
+        cursor = page_info["endCursor"]
+        nodes.extend(result_json["data"]["query"]["nodes"])
+
+        # print(result_json["data"]["query"]["nodes"])
+
+    contributors = defaultdict(lambda: defaultdict(list))
+
+    for node in nodes:
+        pr_num = node["number"]
+        author = node["author"]["login"]
+        reviewers = {r["author"]["login"] for r in node["reviews"]["nodes"]} - {author, bot}
+        commenters = {r["author"]["login"] for r in node["comments"]["nodes"]} - {author, bot}
+
+        contributors[author]["authored_prs"].append(pr_num)
+
+        for login in reviewers:
+            contributors[login]["reviewed_prs"].append(pr_num)
+
+        for login in commenters:
+            contributors[login]["commented_prs"].append(pr_num)
+
+    for login in contributors:
+        authored_prs = contributors[login]["authored_prs"]
+        reviewed_prs = contributors[login]["reviewed_prs"]
+        commented_prs = contributors[login]["commented_prs"]
+        participated_prs = list(set(authored_prs + reviewed_prs + commented_prs))
+
+        contributors[login]["authored_prs"] = sorted(authored_prs, reverse=True)
+        contributors[login]["reviewed_prs"] = sorted(reviewed_prs, reverse=True)
+        contributors[login]["commented_prs"] = sorted(commented_prs, reverse=True)
+        contributors[login]["participated_prs"] = sorted(participated_prs, reverse=True)
+
+        contributors[login]["total_prs"] = len(participated_prs)
+
+    # print(json.dumps(contributors, indent=2, sort_keys=True))
+
+    return contributors
+
+
+if __name__ == '__main__':
+    force_ipv4()
+    contributors = get_contributors()
+
+    print(f"KServe contributors by number of PRs authored or reviewed since %s:\n" % six_months_ago.strftime('%Y-%m-%d'))
+
+    for login, pr_lists in sorted(contributors.items(),
+                                  key=lambda item: item[1]["total_prs"],
+                                  reverse=True):
+
+        num_prs = len(pr_lists["participated_prs"])
+        prs_str = str(pr_lists["participated_prs"])
+        prs_str = (prs_str[:60] + ' ... ]') if len(prs_str) > 60 else prs_str
+
+        print("%3d  %-18s %s" % (num_prs, login, prs_str))

--- a/scripts/python/verify-doc-links.py
+++ b/scripts/python/verify-doc-links.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 The KServe Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.#
+
+# This script finds MD-style links and URLs in markdown file and verifies
+# that the referenced resources exist.
+
+import concurrent.futures
+import itertools
+import re
+from datetime import datetime, timedelta
+from glob import glob
+from os import environ as env
+from os.path import abspath, dirname, exists, relpath
+from time import sleep
+from urllib.request import Request, urlopen
+from urllib.parse import urlparse
+from urllib.error import URLError, HTTPError
+
+
+GITHUB_REPO = env.get("GITHUB_REPO", "https://github.com/kserve/community/")
+BRANCH = "main"
+
+# glob expressions to find markdown files in project
+md_file_path_expressions = [
+    "/**/*.md",
+    "/.github/**/*.md",
+]
+
+# don't process .md files in excluded folders
+excluded_paths = [
+    "/node_modules/",
+    "/temp/",
+    "/.venv/",
+]
+
+# don't analyze URLs with variables to be replaced by the user
+url_excludes = ["<", ">", "$", "{", "}"]
+
+# also exclude non-public or local URLs in a <host>:<port> style
+url_excludes.extend([
+    "0.0.0.0",
+    ":80",
+    ":90",
+    ":port",
+    ":predict",
+    ".default",
+    "blob.core.windows.net",
+    "customdomain.com",
+    "example.com",
+    "localhost",
+    "somecluster",
+    "sslip.io",
+    "svc.cluster.local",
+    "xip.io",
+])
+
+# GitHub rate-limiting is 60 requests per minute, then we sleep a bit
+parallel_requests = 60  # use no more than 60 parallel requests
+retry_wait = 60  # 1 minute before retrying GitHub requests after 429 error
+extra_wait = 5  # additional wait time before retrying GitHub requests
+
+script_folder = abspath(dirname(dirname(__file__)))
+project_root_dir = abspath(dirname(script_folder))
+github_repo_master_path = "{}/blob/{}".format(GITHUB_REPO.rstrip("/"), BRANCH)
+url_status_cache = dict()
+
+
+def find_md_files() -> [str]:
+
+    list_of_lists = [glob(project_root_dir + path_expr, recursive=True)
+                     for path_expr in md_file_path_expressions]
+
+    flattened_list = list(itertools.chain(*list_of_lists))
+
+    filtered_list = [path for path in flattened_list
+                     if not any(s in path for s in excluded_paths)]
+
+    return sorted(filtered_list)
+
+
+def get_links_from_md_file(md_file_path: str) -> [(int, str, str)]:  # -> [(line, link_text, URL)]
+
+    with open(md_file_path, "r") as f:
+        try:
+            md_file_content = f.read()
+        except ValueError as e:
+            print(f"Error trying to load file {md_file_path}")
+            raise e
+
+    folder = relpath(dirname(md_file_path), project_root_dir)
+
+    # replace relative links that are siblings to the README, i.e. [link text](FEATURES.md)
+    md_file_content = re.sub(
+        r"\[([^]]+)\]\((?!http|#|/)([^)]+)\)",
+        r"[\1]({}/{}/\2)".format(github_repo_master_path, folder).replace("/./", "/"),
+        md_file_content)
+
+    # replace links that are relative to the project root, i.e. [link text](/sdk/FEATURES.md)
+    md_file_content = re.sub(
+        r"\[([^]]+)\]\(/([^)]+)\)",
+        r"[\1]({}/\2)".format(github_repo_master_path),
+        md_file_content)
+
+    # find all the links
+    line_text_url = []
+    for line_number, line_text in enumerate(md_file_content.splitlines()):
+
+        all_urls_in_this_line = set()
+
+        # find markdown-styled links [text](url)
+        for (link_text, url) in re.findall(r"\[([^][]+)\]\((%s[^)]+)\)" % "http", line_text):
+            if not any(s in url for s in url_excludes):
+                line_text_url.append((line_number + 1, link_text, url))
+                all_urls_in_this_line.add(url)
+
+        # find plain http(s)-style links
+        for url in re.findall(r"https?://[a-zA-Z0-9./?=_&%${}<>:-]+", line_text):
+            if url not in all_urls_in_this_line\
+                    and not any(s in url for s in url_excludes):
+                try:
+                    urlparse(url)
+                    line_text_url.append((line_number + 1, "", url.strip(".")))
+                except URLError:
+                    pass
+
+    # return completed links
+    return line_text_url
+
+
+def test_url(file: str, line: int, text: str, url: str) -> (str, int, str, str, int):  # (file, line, text, url, status)
+
+    short_url = url.split("#", maxsplit=1)[0]
+    status = 0
+
+    if short_url not in url_status_cache:
+
+        # mind GitHub rate-limiting, use local files to verify link
+        if short_url.startswith(github_repo_master_path):
+            local_path = short_url.replace(github_repo_master_path, "")
+            if exists(abspath(project_root_dir + local_path)):
+                status = 200
+            else:
+                status = 404
+        else:
+            status = request_url(short_url, method="HEAD")
+
+        if status == 403:  # forbidden, try with web browser header
+            headers = {
+                "User-Agent": "Mozilla/5.0",            # most pages want User-Agent
+                "Accept-Encoding": "gzip, deflate, br"  # GitHub wants Accept-Encoding
+            }
+            status = request_url(short_url, method="GET", headers=headers)
+
+        if status == 405:  # method not allowed, use GET instead of HEAD
+            status = request_url(short_url, method="GET")
+
+        if status in [429, 503]:  # GitHub rate-limiting or service unavailable, try again after 1 minute
+            sleep(retry_wait + extra_wait)
+            status = request_url(short_url, method="GET")
+
+        if status in [444, 555]:  # other URLError or Exception, retry with longer timeout
+            status = request_url(short_url, method="GET", timeout=15)
+
+        # if we keep getting the same error, mark it as 404 to be reported at the end
+        if status in [444, 555]:
+            status = 404
+
+        url_status_cache[short_url] = status
+
+    status = url_status_cache[short_url]
+
+    return file, line, text, url, status
+
+
+# datetime to wait until before attempting requests to github.com
+next_time_for_github_request = datetime.now()
+
+
+def wait_before_retry(url):
+    global next_time_for_github_request
+    if "github.com" in url:
+        if datetime.now() < next_time_for_github_request:
+            sleep((next_time_for_github_request - datetime.now()).seconds + extra_wait)
+
+
+def set_retry_time(url, status):
+    global next_time_for_github_request
+    if "github.com" in url and status == 429:
+        next_time_for_github_request = datetime.now() + timedelta(seconds=retry_wait + extra_wait)
+
+
+def request_url(url, method="HEAD", timeout=5, headers={}) -> int:
+    wait_before_retry(url)
+    try:
+        req = Request(url, method=method, headers=headers)
+        resp = urlopen(req, timeout=timeout)
+        status = resp.code
+        if any(s in url for s in ["youtube.com", "youtu.be"]):
+            html = resp.read().decode("utf8")
+            if "This video isn't available anymore" in html:
+                status = 404
+        resp.close()
+    except HTTPError as e:
+        status = e.code
+        set_retry_time(url, status)
+    except URLError:
+        status = 444  # custom code used script-internally
+    except Exception:
+        status = 555  # custom code used script-internally
+
+    return status
+
+
+def verify_urls_concurrently(file_line_text_url: [(str, int, str, str)]) -> [(str, int, str, str)]:
+    file_line_text_url_status = []
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallel_requests) as executor:
+        check_urls = (
+            executor.submit(test_url, file, line, text, url)
+            for (file, line, text, url) in file_line_text_url
+        )
+        for url_check in concurrent.futures.as_completed(check_urls):
+            try:
+                file, line, text, url, status = url_check.result()
+                file_line_text_url_status.append((file, line, text, url, status))
+            except Exception:
+                # set 555 status as a custom code used script-internally
+                file_line_text_url_status.append((file, line, text, url, 555))
+            finally:
+                print("{}/{}".format(len(file_line_text_url_status),
+                                     len(file_line_text_url)), end="\r")
+
+    return file_line_text_url_status
+
+
+def verify_doc_links() -> [(str, int, str, str)]:
+
+    # 1. find all relevant Markdown files
+    md_file_paths = find_md_files()
+
+    # 2. extract all links with text and URL
+    file_line_text_url = [
+        (file, line, text, url)
+        for file in md_file_paths
+        for (line, text, url) in get_links_from_md_file(file)
+    ]
+
+    # 3. validate the URLs
+    file_line_text_url_status = verify_urls_concurrently(file_line_text_url)
+
+    # 4. filter for the invalid URLs (status 404: "Not Found") to be reported
+    file_line_text_url_404 = [(f, l, t, u, s)
+                              for (f, l, t, u, s) in file_line_text_url_status
+                              if s == 404]
+
+    # 5. print some stats for confidence
+    print("{} {} links ({} unique URLs) in {} Markdown files.\n".format(
+        "Checked" if file_line_text_url_404 else "Verified",
+        len(file_line_text_url_status),
+        len(url_status_cache),
+        len(md_file_paths)))
+
+    # 6. report invalid links, exit with error for CI/CD
+    if file_line_text_url_404:
+
+        for (file, line, text, url, status) in sorted(file_line_text_url_404):
+            print("{}:{}: {} -> {}".format(
+                relpath(file, project_root_dir), line,
+                url.replace(github_repo_master_path, ""), status))
+
+        # print a summary line for clear error discovery at the bottom of Travis job log
+        print("\nERROR: Found {} invalid Markdown links".format(
+            len(file_line_text_url_404)))
+
+        exit(1)
+
+
+def apply_monkey_patch_to_force_ipv4_connections():
+    # Monkey-patch socket.getaddrinfo to force IPv4 conections, since some older
+    # routers and some internet providers don't support IPv6, in which case Python
+    # will first try an IPv6 connection which will hang until timeout and only
+    # then attempt a successful IPv4 connection
+    import socket
+
+    # get a reference to the original getaddrinfo function
+    getaddrinfo_original = socket.getaddrinfo
+
+    # create a patched getaddrinfo function which uses the original function
+    # but filters out IPv6 (socket.AF_INET6) entries of host and port address infos
+    def getaddrinfo_patched(*args, **kwargs):
+        res = getaddrinfo_original(*args, **kwargs)
+        return [r for r in res if r[0] == socket.AF_INET]
+
+    # replace the original socket.getaddrinfo function with our patched version
+    socket.getaddrinfo = getaddrinfo_patched
+
+
+if __name__ == '__main__':
+    apply_monkey_patch_to_force_ipv4_connections()
+    verify_doc_links()


### PR DESCRIPTION
## Proposed changes in this PR:

- Document the process of how to become a KServe committer
- Add a helper script to find suitable candidates for promotion

---

## Becoming a committer

A committer is a contributor who has gained the privilege to commit code to the project. It also means being committed to the project and the community as a whole.

Contributors who aspire to become committers should already be doing most of the activities that are expected to be done by the project's committers.

**Responsibilities of a committer:**

- Triage and respond to issues
- Possess expertise in certain areas and familiarity with the majority of the code base
- Review pull requests
- Answer questions on Slack
- Mentor new project contributors

Contributors who have demonstrated their proficiency to make substantial code contributions and shown their commitment to the projects success over a prolonged period of time are candidates to become committers.

**How new committers are chosen:**

The [KServe Technical Charter](./KSERVE-TECHICAL-CHARTER.md#2-technical-steering-committee) outlines the process to become a KServe committer:

> - **iii**. A _Contributor_ may become a _Committer_ by a majority approval of the existing Committers. A Committer may be removed by a majority approval of the other existing Committers. 

For this purpose, the technical steering committee (TSC) shall periodically review the activity of project contributors and propose qualifying contributors to be promoted to become committers.

To help find candidates for promotion, existing committers can use the [`list-contributors.py`](scripts/python/list-contributors.py) script to review recent contributor activity:

```shell
$ make list-pr-authors

Contributors to 'kserve/kserve' (PR authors) by number of PRs (>3) since 2023-03-02:

 39  supercoder      [5083, 5077, 5040, 5038, 5035, 5031, 5024, 5016, 5006, 5004, ... ]
 20  kservehacker    [5089, 5061, 5054, 5029, 5020, 5002, 5001, 4998, 4956, 4952, ... ]
  6  code4fun        [5069, 5048, 5027, 5026, 5008, 4867]
```
```
$ make list-pr-reviewers

Contributors to 'kserve/kserve' (PR commenters, reviewers) by number of PRs (>3) since 2023-03-02:

 13  reviewchamp     [5089, 5075, 5072, 5047, 5042, 5040, 5038, 5031, 4993, 4969, ... ]
  9  nitpickr        [5079, 5054, 5049, 5040, 4954, 4877, 4782, 4762, 4739]
  4  casualcodr      [5062, 5039, 5025, 4867]
```

This script should only be used to identify suitable candidates. The actual candidate selection should take more factors into consideration than number of commits or PRs reviewed.

**Areas of expertise:**

Another criterion to use when selecting new committers is the project area that requires help with reviewing PRs and mentoring new contributors. Contributors that have a lot of expertise in a particular area who have helped review PRs in that area make good candidates to be promoted as committers. The various projects under the KServe umbrella may have a different set of committers and focus areas.

Some of those areas of expertise include:

- **KServe**:
  - Python SDK
  - Open inference protocol, data plane
  - Release & testing infra
  - Webapp
  - Website
- **ModelMesh**:
  - Controller
  - Runtime adapter
  - Storage adapter
  - Rest proxy
