### PR TITLE
Equivalent role of committer/approver and TSC member

### DIFF
--- a/TECHNICAL-STEERING-COMMITTEE.md
+++ b/TECHNICAL-STEERING-COMMITTEE.md
@@ -1,15 +1,3 @@
 # Technical Steering Committee
 
-The Technical Steering Committee (TSC) will be responsible for all technical oversight of the open source Project. Please see [the charter](KSERVE-TECHNICAL-CHARTER.md) for more details.
-
-## Committee members
-
-The current membership of the committee is (listed alphabetically by first name):
-
-| Name                   | Organization | GitHub                                             |
-|------------------------|--------------|----------------------------------------------------|
-| Dan Sun                | Bloomberg    | [yuzisun](https://github.com/yuzisun/)             |
-| Johnu George           | Nutanix      | [johnugeorge](https://github.com/johnugeorge/)     |
-| Lize Cai               | SAP          | [lizzzcai](https://github.com/lizzzcai/)           |
-| Sivanantham Chinnaiyan | Idea2IT      | [sivanantha321](https://github.com/sivanantha321/) |
-| Yuan Tang              | Red Hat      | [terrytangyuan](https://github.com/terrytangyuan/) |
+The Technical Steering Committee (TSC) will be responsible for all technical oversight of the open source Project. It consists of all [committers/approvers](MAINTAINERS.md) of the project. Please see [the charter](KServe%20Technical%20Charter%20Final.pdf) for more details.

--- a/membership.md
+++ b/membership.md
@@ -145,8 +145,8 @@ an `OWNERS` file.
 #### Approver/Committer
 
 Code approvers are able to both review and approve code contributions as well as 
-help subproject leads triage issues and with project management. Note that committer
-is equivalent to committer and is a member of the [Technical Steering Committee (TSC)](TECHNICAL-STEERING-COMMITTEE.md).
+help subproject leads triage issues and with project management. Note that "committer"
+is equivalent to "approver" and can be used interchangeably. An approver is a member of the [Technical Steering Committee (TSC)](TECHNICAL-STEERING-COMMITTEE.md).
 
 While code review is focused on code quality and correctness, approval is focused on
 holistic acceptance of a contribution including: backwards / forwards

--- a/membership.md
+++ b/membership.md
@@ -8,7 +8,7 @@ Responsibilities for roles are scoped to these subprojects.
 |----------|:----------------------------------------------|:------------------------------------------------------------------------------------------|:---------------------------|
 | member   | active contributor in the community           | sponsored by 2 approvers or leads. multiple contributions to the project                  | KServe GitHub org member   |
 | reviewer | review contributions from other members       | sponsored by a lead. history of review and authorship in a subproject                     | OWNERS file reviewer entry |
-| approver | approve accepting contributions               | sponsored by a lead. highly experienced and active reviewer + contributor to a subproject | OWNERS file approver entry |
+| approver/committer | approve accepting contributions               | sponsored by a lead. highly experienced and active reviewer + contributor to a subproject | OWNERS file approver entry |
 | lead     | set direction and priorities for a subproject | demonstrated responsibility and excellent technical judgement for the subproject          | OWNERS file owner entry    |
 
 Please see [MAINTAINERS.md](MAINTAINERS.md) for a list of existing members and their roles.
@@ -142,10 +142,11 @@ an `OWNERS` file.
 
 
 
-#### Approver
+#### Approver/Committer
 
 Code approvers are able to both review and approve code contributions as well as 
-help subproject leads triage issues and with project management.
+help subproject leads triage issues and with project management. Note that committer
+is equivalent to committer and is a member of the [Technical Steering Committee (TSC)](TECHNICAL-STEERING-COMMITTEE.md).
 
 While code review is focused on code quality and correctness, approval is focused on
 holistic acceptance of a contribution including: backwards / forwards


### PR DESCRIPTION
This addresses https://github.com/kserve/community/issues/57. We'd like to remove the explicit list of KSC members to avoid any election process, which would cause a lot of unnecessary administrative work. This also allows us to keep the existing technical charter carried over from LF AI & Data (any further changes requires LF approval).