### PR TITLE
chore: promote two reviewers to approvers and add new reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @yuzisun @terrytangyuan @johnugeorge @lizzzcai @sivanantha321
+* @yuzisun @terrytangyuan @johnugeorge @lizzzcai @sivanantha321 @spolti @cjohannsen-cloudera

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,6 +11,8 @@ Please see [membership.md](membership.md) that defines the various responsibilit
 | Lize Cai               | [lizzzcai](https://github.com/lizzzcai)               | Approver - KServe    | SAP         |
 | Sivanantham Chinnaiyan | [sivanantha321](https://github.com/sivanantha321)     | Approver - KServe    | Ideas2IT    |
 | Jooho Lee              | [Jooho](https://github.com/Jooho)                     | Approver - KServe    | Red Hat     |
+| Cory Johannsen         | [cjohannsen-cloudera](https://github.com/cjohannsen-cloudera) | Approver - KServe | Cloudera |
+| Filippe Spolti         | [spolti](https://github.com/spolti)                   | Approver - KServe    | Red Hat     |
 | Andrews Arokiam        | [andyi2it](https://github.com/andyi2it)               | Reviewer - KServe    | Ideas2IT    |
 | Cory Johannsen         | [cjohannsen-cloudera](https://github.com/cjohannsen-cloudera) | Reviewer - KServe | Cloudera |
 | Curtis Maddalozzo      | [cmaddalozzo](https://github.com/cmaddalozzo)         | Reviewer - KServe    | Bloomberg   |
@@ -19,8 +21,8 @@ Please see [membership.md](membership.md) that defines the various responsibilit
 | Jin Dong               | [greenmoon55](https://github.com/greenmoon55)         | Reviewer - KServe    | Bloomberg   |
 | Edgar Hernández        | [israel-hdez](https://github.com/israel-hdez)         | Reviewer - KServe    | Red Hat     |
 | Johnu George           | [johnugeorge](https://github.com/johnugeorge)         | Reviewer - KServe    | Nutanix     |
-| Filippe Spolti         | [spolti](https://github.com/spolti)                   | Reviewer - KServe    | Red Hat     |
 | Pierangelo Di Pilato   | [pierDipi](https://github.com/pierDipi)               | Reviewer - KServe    | Red Hat     |
+| Bartosz Majsak         | [bartoszmajsak](https://github.com/bartoszmajsak)     | Reviewer - KServe    | Red Hat     |
 
 
 ## Alumni


### PR DESCRIPTION
This PR promotes two active reviewers to approvers and adds a new reviewer to the maintainers list.

## Changes

- **Promote Cory Johannsen (@cjohannsen-cloudera)** from reviewer to approver - Cloudera
- **Promote Filippe Spolti (@spolti)** from reviewer to approver - Red Hat  
- **Add Bartosz Majsak (@bartoszmajsak)** as new reviewer - Red Hat

## Files Modified

- `MAINTAINERS.md` - Updated roles and added new member
- `OWNERS` - Updated permissions to reflect new approver/reviewer status

These changes align with the community recognition of valuable contributors and expand our review capacity.

## Tickets
- https://github.com/kserve/community/issues/70
- https://github.com/kserve/community/issues/68
- https://github.com/kserve/community/issues/65