### PR TITLE
Clarify promotion requirements by splitting author and reviewer contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/promotion-approver.md
+++ b/.github/ISSUE_TEMPLATE/promotion-approver.md
@@ -24,19 +24,24 @@ Promotion is requested for the following sub-project(s).
 
 ### Requirements
 
-
 - [ ] Reviewer for at least 3 months (as of the membership meeting date)
-- [ ] Reviewer for or author of at least 10 substantial PRs to the codebase
-   - < link to PR 1 >
-   - < link to PR 2 >
-   - < link to PR 3 >
-   - < link to PR 4 >
-   - < link to PR 5 >
-   - < link to PR 6 >
-   - < link to PR 7 >
-   - < link to PR 8 >
-   - < link to PR 9 >
-   - < link to PR 10 >
+- [ ] Author of at least 5 substantial PRs (merged)
+   - < link to authored PR 1 >
+   - < link to authored PR 2 >
+   - < link to authored PR 3 >
+   - < link to authored PR 4 >
+   - < link to authored PR 5 >
+- [ ] Primary reviewer for at least 10 substantial PRs from other contributors
+   - < link to reviewed PR 1 >
+   - < link to reviewed PR 2 >
+   - < link to reviewed PR 3 >
+   - < link to reviewed PR 4 >
+   - < link to reviewed PR 5 >
+   - < link to reviewed PR 6 >
+   - < link to reviewed PR 7 >
+   - < link to reviewed PR 8 >
+   - < link to reviewed PR 9 >
+   - < link to reviewed PR 10 >
 
 ### Sponsors
 

--- a/.github/ISSUE_TEMPLATE/promotion-reviewer.md
+++ b/.github/ISSUE_TEMPLATE/promotion-reviewer.md
@@ -21,12 +21,16 @@ Promotion is requested for the following sub-project(s).
 ### Requirements
 
 - [ ] Member for at least 3 months (as of the membership meeting date)
-- [ ] Reviewer for or author of at least 5 substantial PRs to the codebase
-    - < link to PR 1 >
-    - < link to PR 2 >
-    - < link to PR 3 >
-    - < link to PR 4 >
-    - < link to PR 5 >
+- [ ] Author of at least 3 substantial PRs (merged)
+    - < link to authored PR 1 >
+    - < link to authored PR 2 >
+    - < link to authored PR 3 >
+- [ ] Primary reviewer for at least 5 substantial PRs from other contributors
+    - < link to reviewed PR 1 >
+    - < link to reviewed PR 2 >
+    - < link to reviewed PR 3 >
+    - < link to reviewed PR 4 >
+    - < link to reviewed PR 5 >
 
 ### Sponsors
 

--- a/membership.md
+++ b/membership.md
@@ -116,9 +116,12 @@ an `OWNERS` file.
 
 - Member for at least 3 months
 - Active community participation (meetings, slack, stack overflow) and interact with issues for at least 1 month.
-- Reviewer for or author of at least 5 substantial PRs to the codebase, with the
-  definition of substantial subject to the lead's discretion (e.g.
-  refactors, enhancements rather than grammar correction or one-line pulls).
+- Author of at least 3 substantial PRs (merged) to the codebase
+- Primary reviewer for at least 5 substantial PRs from other contributors
+  - Bot commands (`/lgtm`, `/approve`, `/retest`, etc.) or comments shorter than 10 characters do not count as reviews
+  - Self-reviews (reviews on PRs authored by the reviewer themselves) do not count
+- The definition of substantial is subject to the lead's discretion
+  (e.g. refactors, enhancements rather than grammar correction or one-line pulls).
 - Knowledgeable about the codebase
 - Sponsored by a project lead
   - With no objections from other leads
@@ -163,9 +166,13 @@ The following apply to the part of codebase for which one would be an approver
 in an `OWNERS` file.
 
 - Reviewer for at least 3 months
-- Reviewer for or author of at least 10 substantial PRs to the codebase, with the
-  definition of substantial subject to the lead's discretion (e.g.
-  refactors, enhancements rather than grammar correction or one-line pulls).
+- Author of at least 5 substantial PRs (merged) to the codebase
+- Primary reviewer for at least 10 substantial PRs from other contributors
+  - Reviews must span across different PRs (multiple comments on the same PR count as one review)
+  - Bot commands (`/lgtm`, `/approve`, `/retest`, etc.) or comments shorter than 10 characters do not count as reviews
+  - Self-reviews (reviews on PRs authored by the reviewer themselves) do not count
+- The definition of substantial is subject to the lead's discretion
+  (e.g. refactors, enhancements rather than grammar correction or one-line pulls).
 - Exhibiting sound technical judgment through PR contributions
 - Exhibiting sound technical judgment through PR reviews
 - Sponsored by a project lead
@@ -268,6 +275,15 @@ After an extended period away from the project with no activity,
 removed members would need to re-familiarize themselves with the current state
 before being able to contribute effectively.
 
+### Inactive maintainers
+
+Reviewers and approvers with no meaningful contributions (PRs authored, PRs reviewed, or issue
+triage) for 12 months may be discussed for demotion or emeritus transition at the quarterly
+membership meeting by the project leads and approvers.
+
+Emeritus maintainers are welcome to rejoin at any time. Returning maintainers who were previously
+in good standing may be fast-tracked through the promotion process at the discretion of the
+project leads.
 
 ### Change in membership roles
 


### PR DESCRIPTION
## Summary

Current promotion criteria count author and reviewer contributions together ("Reviewer for or author of at least N substantial PRs"), which means someone can reach the bar without ever reviewing another contributor's code. That's a problem for Approvers whose main job is to review and merge PRs.

This splits the requirements:

- **Reviewer**: 3 authored merged PRs + 5 reviewed PRs
- **Approver**: 5 authored merged PRs + 10 reviewed PRs

Numbers are roughly 1/3 of Kubernetes thresholds, scaled for KServe's size.

Also adds noise filtering — bot commands (`/lgtm`, `/approve`, `/retest`), comments under 10 chars, and self-reviews don't count toward review totals.

Adds an inactive maintainers clause: 12 months no activity triggers a discussion at the quarterly membership meeting, not automatic removal.