### PR TITLE
Count reviews by submission date, fix tenure month fraction

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -94,12 +94,22 @@ python3 scripts/python/governance-check.py --repo kserve/modelmesh-serving
 
 ### How reviews are counted
 
-A PR counts as "reviewed" if the user either:
+A PR counts as "reviewed" if the user, on a PR they did not author, either:
 
 - Submitted a review with COMMENTED or CHANGES_REQUESTED state, or
-- Left a general comment that passes the noise filter (not a bot command, 10+ characters, not on their own PR)
+- Wrote substantive text in a review body or a general comment — text that
+  passes the noise filter (not a bot command, 10+ characters)
 
-Multiple comments on the same PR count as one review.
+Substance is judged by content, not by which button was clicked. A bare
+approval (an empty APPROVED review or `/lgtm`) is a rubber stamp and does
+**not** count. But an approval submitted together with real written feedback
+does count — the feedback itself is the review.
+
+Each review is attributed to the date it was submitted (the review/comment
+timestamp), not the date the PR was opened. A review left recently on an older
+PR still counts toward the recent measurement window.
+
+Multiple reviews or comments on the same PR count as one review.
 
 ## List Contributors
 

--- a/scripts/python/governance-check.py
+++ b/scripts/python/governance-check.py
@@ -147,12 +147,14 @@ PR_QUERY = """
             author { login }
             state
             body
+            submittedAt
           }
         }
         comments(first: 50) {
           nodes {
             author { login }
             body
+            createdAt
           }
         }
       }
@@ -319,7 +321,11 @@ def build_activity(pr_nodes):
             activity[pr_author]["authored"].append({
                 **pr_info, "merged_at": pr["mergedAt"][:10]})
 
-        reviewers_on_this_pr = set()
+        # Track the most recent qualifying review/comment date per user, so
+        # window filtering reflects when the review actually happened rather
+        # than when the PR was opened. Falls back to PR creation date if the
+        # timestamp is missing.
+        reviewer_dates = {}
         pr_created = pr["createdAt"][:10]
 
         for review in pr.get("reviews", {}).get("nodes", []):
@@ -330,7 +336,9 @@ def build_activity(pr_nodes):
                 continue
             if is_formal_review(review.get("state", ""), pr_author, reviewer) or \
                is_valid_review(review.get("body", ""), pr_author, reviewer):
-                reviewers_on_this_pr.add(reviewer)
+                when = (review.get("submittedAt") or pr_created)[:10]
+                if when > reviewer_dates.get(reviewer, ""):
+                    reviewer_dates[reviewer] = when
 
         for comment in pr.get("comments", {}).get("nodes", []):
             if not comment or not comment.get("author"):
@@ -339,10 +347,12 @@ def build_activity(pr_nodes):
             if commenter in IGNORED_USERS or commenter == pr_author:
                 continue
             if is_valid_review(comment.get("body", ""), pr_author, commenter):
-                reviewers_on_this_pr.add(commenter)
+                when = (comment.get("createdAt") or pr_created)[:10]
+                if when > reviewer_dates.get(commenter, ""):
+                    reviewer_dates[commenter] = when
 
-        for reviewer in reviewers_on_this_pr:
-            activity[reviewer]["reviewed"].append({**pr_info, "date": pr_created})
+        for reviewer, when in reviewer_dates.items():
+            activity[reviewer]["reviewed"].append({**pr_info, "date": when})
 
     return activity
 
@@ -380,9 +390,14 @@ def deduplicate_reviewed(reviewed):
 
 def compute_tenure_activity(user_data, reviewer_since_str):
     since = datetime.strptime(reviewer_since_str, "%Y-%m-%d").date()
+    today = date.today()
     authored = filter_by_date(user_data["authored"], "merged_at", since)
     reviewed = deduplicate_reviewed(filter_by_date(user_data["reviewed"], "date", since))
-    months = max(1, (date.today() - since).days // 30)
+    months = max(1, (today - since).days // 30)
+    # Calendar months the tenure spans, inclusive of both endpoints. Used as the
+    # denominator for months_with_activity (which also counts calendar months),
+    # so the fraction stays consistent instead of e.g. 4/3.
+    calendar_months = (today.year - since.year) * 12 + (today.month - since.month) + 1
 
     active_months = set()
     for r in reviewed:
@@ -397,7 +412,7 @@ def compute_tenure_activity(user_data, reviewer_since_str):
         "reviewed_during_tenure": len(reviewed),
         "avg_reviews_per_month": round(len(reviewed) / months, 1),
         "months_with_activity": len(active_months),
-        "months_total": months,
+        "months_total": calendar_months,
     }
 
 


### PR DESCRIPTION
governance-check.py attributed each review to the PR creation date, so a recent review on an older PR fell outside the measurement window and got dropped. Reviews now count toward the window by when they were actually submitted (review submittedAt / comment createdAt), falling back to the PR creation date only when the timestamp is missing.

Also fixes the reviewer-tenure activity fraction. months_with_activity counts calendar months but the denominator used 30-day chunks, so it could print impossible values like 4/3. The denominator is now the calendar months the tenure spans. The tenure gate (>= 3 months) and avg-per-month are unchanged.

README updated to describe how reviews are counted — content-based: a bare approve / `/lgtm` is a rubber stamp and doesn't count, substantive written feedback does, regardless of the review button.