### PR TITLE
docs: add Traditional Chinese Code of Conduct link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -20,6 +20,7 @@ Other languages available:
 - [Portuguese/Português](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/pt.md)
 - [Russian/Русский](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/ru.md)
 - [Spanish/Español](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/es.md)
+- [Traditional Chinese/繁體中文](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/zh-tw.md)
 - [Turkish/Türkçe](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/tr.md)
 - [Ukrainian/Українська](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/uk.md)
 - [Vietnamese/Tiếng Việt](https://github.com/cncf/foundation/blob/main/code-of-conduct-languages/vi.md)


### PR DESCRIPTION
## What this PR does

Adds the missing Traditional Chinese Code of Conduct link to the list of available translations.

The Traditional Chinese (`zh-tw`) translation is already available in the CNCF Foundation repository and is listed in the upstream CNCF Code of Conduct.

## Changes

- Add `Traditional Chinese/繁體中文` to the available language list.
- Link to the existing CNCF `zh-tw.md` translation.