### PR TITLE
docs: Update outdated documentation links in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ following steps:
 
 - Submit PRs to [kserve/website](https://github.com/kserve/website) with
   documentation for your feature, including usage examples when possible.
-  See [here](https://github.com/kserve/website/blob/main/docs/help/contributor/mkdocs-contributor-guide.md) to learn how to write docs for kserve.io.
+  See [here](https://github.com/kserve/website/blob/main/docs/developer-guide/contribution.md) to learn how to write docs for kserve.io.
 
 Note, that we prefer "bite-sized" PRs instead of "giant monster" PRs. It is
 preferable if you can introduce large features in smaller reviewable changes
@@ -86,7 +86,7 @@ discussions, so the choice is up to you.
 ## Setting up to contribute to KServe
 
 Check out this [README](https://github.com/kserve/kserve/blob/master/README.md)
-to learn about the KServe source base and setting up your [development environment](https://kserve.github.io/website/master/developer/developer/).
+to learn about the KServe source base and setting up your [development environment](https://kserve.github.io/website/docs/developer-guide).
 
 ## Pull requests
 
@@ -171,12 +171,12 @@ For more information about our security practices, please visit our [Security Po
 ## Add your organization to adopters
 
 If your organization uses KServe, you can list it on our
-[adopters page](https://kserve.github.io/website/master/community/adopters).
+[adopters page](https://kserve.github.io/website/docs/community/adopters).
 We have categories for *providers* (who offer hosted or managed KServe services
 to their customers), *end users* (who use and consume KServe) and *integrations*
 (commercial or open source products that work with KServe).
 
-Please add your organization's logo, preferably in SVG format [here](https://github.com/kserve/website/tree/main/docs/images).
+Please add your organization's logo, preferably in SVG format [here](https://github.com/kserve/website/tree/main/static/img/adopters).
 
 ## Project membership
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ KServe is an open source project that is driven by the participation of users an
 
 ### Become a contributor
 1. Familiar youself with the [KServe contribution guideline](https://github.com/kserve/community/blob/main/CONTRIBUTING.md#contributing-a-feature).
-2. The [KServe developer guideline](https://kserve.github.io/website/master/developer/developer), [doc contributor guideline](https://github.com/kserve/website/blob/main/docs/help/contributor/mkdocs-contributor-guide.md) is the starting point for contributors to make code or doc contributions.
-3. To dig deeper, check out the [KServe user guide](https://kserve.github.io/website/master/modelserving/control_plane)
+2. The [KServe developer guideline](https://kserve.github.io/website/docs/developer-guide), [doc contributor guideline](https://github.com/kserve/website/blob/main/docs/developer-guide/contribution.md) is the starting point for contributors to make code or doc contributions.
+3. To dig deeper, check out the [KServe user guide](https://kserve.github.io/website/docs/concepts/architecture/control-plane)
 and read some [design docs](./CONTRIBUTING.md#design-documents), see past design docs [here](./design_docs.md).
 4. Participate in the KServe working group.
 


### PR DESCRIPTION
## What this PR does

This PR updates outdated and broken documentation links in `README.md` and `CONTRIBUTING.md`.

Changes include:

* Update outdated KServe Developer Guide links.
* Replace the removed documentation contributor guide with the current Contribution Guide.
* Update the Control Plane documentation link.
* Update the adopters page link.
* Update the outdated adopter logo directory path.

## Why

Some links still reference the previous KServe documentation structure or files that no longer exist after the website documentation migration.

The updated links preserve the existing link behavior where possible:

* rendered documentation links continue to point to the KServe documentation website;
* source documentation links continue to point to files in `kserve/website`;
* the adopter logo link is updated to the current logo directory.

## Verification

* Verified that the updated links are valid.
* Only `README.md` and `CONTRIBUTING.md` are changed.
* Documentation-only changes; no code or tests are affected.

Fixes #83